### PR TITLE
DATE_FORMAT_LC6 - добавил потерянные секунды в формат

### DIFF
--- a/administrator/language/ru-RU/joomla.ini
+++ b/administrator/language/ru-RU/joomla.ini
@@ -865,7 +865,7 @@ DATE_FORMAT_LC2="l, d F Y, H:i"
 DATE_FORMAT_LC3="d F Y"
 DATE_FORMAT_LC4="d.m.Y"
 DATE_FORMAT_LC5="d.m.Y, H:i"
-DATE_FORMAT_LC6="d.m.Y, H:i"
+DATE_FORMAT_LC6="d.m.Y, H:i:s"
 
 ; Months
 JANUARY_SHORT="янв"
@@ -963,3 +963,4 @@ UNPUBLISHED="Не опубликовано"
 
 ; Overriding or duplicating strings (only for ru-RU package)
 UNCATEGORISED="Без категории"
+


### PR DESCRIPTION
`DATE_FORMAT_LC6` в должна быть `d.m.Y, H:i:s` вместо `d.m.Y, H:i`, иначе она полностью совпадает с `DATE_FORMAT_LC5`. В английской локализации она отображает секунды. а в русской - нет. 

<img width="1220" height="486" alt="Image" src="https://github.com/user-attachments/assets/d01f09e4-0ec1-4005-9031-b16e1127c12d" />